### PR TITLE
feat: handle optional note ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Changed functionality when `note_id_func` returns an empty string to remove leading `|`
+
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ This is a complete list of all of the options that can be passed to `require("ob
     new_notes_location = "current_dir"
   },
 
-  -- Optional, customize how names/IDs for new notes are created.
+  -- Optional, customize how names/IDs for new notes are created. If nil or an empty string
+  -- is returned the id will be ignored.
   note_id_func = function(title)
     -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
     -- In this case a note with the title 'My new note' will given an ID that looks

--- a/lua/cmp_obsidian_new.lua
+++ b/lua/cmp_obsidian_new.lua
@@ -23,12 +23,16 @@ source.complete = function(self, request, callback)
   if can_complete and search ~= nil and #search >= opts.completion.min_chars then
     local new_id = client:new_note_id(search)
     local items = {}
+    local new_title = search
+    if new_id ~= '' and new_id ~= nil then
+        new_title = new_id .. '|' .. search
+    end
     table.insert(items, {
       sortText = "[[" .. search,
-      label = "Create: [[" .. new_id .. "|" .. search .. "]]",
+      label = "Create: [[" .. new_title .. "]]",
       kind = 18,
       textEdit = {
-        newText = "[[" .. new_id .. "|" .. search .. "]]",
+        newText = "[[" .. new_title .. "]]",
         range = {
           start = {
             line = request.context.cursor.row - 1,


### PR DESCRIPTION
Has been tested and confirmed working with the following configuration:
```lua
note_id_func = function (_)
    return ''
end
```
![image](https://github.com/NachoxMacho/obsidian.nvim/assets/10048014/d5703858-1150-4fe3-9cdc-c5494c8062b7)
